### PR TITLE
Minimum changes required to be compatible with SwaggerGen v10.

### DIFF
--- a/SignalRSwaggerGen/SignalRSwaggerGen/SignalRSwaggerGen.cs
+++ b/SignalRSwaggerGen/SignalRSwaggerGen/SignalRSwaggerGen.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.AspNetCore.Authorization;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using SignalRSwaggerGen.Attributes;
 using SignalRSwaggerGen.Enums;
 using SignalRSwaggerGen.Utils;
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
@@ -94,15 +95,15 @@ namespace SignalRSwaggerGen
 				methodPath,
 				new OpenApiPathItem
 				{
-					Operations = new Dictionary<OperationType, OpenApiOperation>
+					Operations = new Dictionary<HttpMethod, OpenApiOperation>
 					{
 						{
-							(OperationType)operation,
+							new HttpMethod(operation.ToString()),
 							new OpenApiOperation
 							{
 								Summary = summary,
 								Description = description,
-								Tags = new List<OpenApiTag> { new OpenApiTag { Name = tag } },
+								Tags = new HashSet<OpenApiTagReference> { new(tag) },
 								Parameters = ToOpenApiParameters(context, hubAttribute, methodParams, methodXml).ToList(),
 								Responses = ToOpenApiResponses(context, methodReturnParam),
 								RequestBody =  GetOpenApiRequestBody(context, method),
@@ -125,23 +126,13 @@ namespace SignalRSwaggerGen
 				{
 					new OpenApiSecurityRequirement
 					{
-						{
-							new OpenApiSecurityScheme
-							{
-								Reference = new OpenApiReference
-								{
-									Type = ReferenceType.SecurityScheme,
-									Id = "basic",
-								}
-							},
-							Array.Empty<string>()
-						}
+						[new OpenApiSecuritySchemeReference("basic", null)] = []
 					}
 				}
 				: null;
 		}
 
-		private static IEnumerable<OpenApiParameter> ToOpenApiParameters(
+		private static IEnumerable<IOpenApiParameter> ToOpenApiParameters(
 			DocumentFilterContext context,
 			SignalRHubAttribute hubAttribute,
 			IEnumerable<ParameterInfo> parameters,
@@ -202,22 +193,14 @@ namespace SignalRSwaggerGen
 			};
 		}
 
-		private static OpenApiSchema GetOpenApiSchema(DocumentFilterContext context, Type type)
+		private static IOpenApiSchema GetOpenApiSchema(DocumentFilterContext context, Type type)
 		{
-			if (!context.SchemaRepository.TryLookupByType(type, out OpenApiSchema schema))
+			if (context.SchemaRepository.TryLookupByType(type, out var schemaReference))
 			{
-				schema = context.SchemaGenerator.GenerateSchema(type, context.SchemaRepository);
+				return schemaReference;
 			}
-			return schema.Reference == null
-				? schema
-				: new OpenApiSchema
-				{
-					Reference = new OpenApiReference
-					{
-						Id = schema.Reference.Id,
-						Type = ReferenceType.Schema
-					}
-				};
+
+			return context.SchemaGenerator.GenerateSchema(type, context.SchemaRepository);
 		}
 
 		private static Dictionary<string, OpenApiMediaType> GetContentByMediaType(OpenApiMediaType mediaType)

--- a/SignalRSwaggerGen/SignalRSwaggerGen/SignalRSwaggerGen.csproj
+++ b/SignalRSwaggerGen/SignalRSwaggerGen/SignalRSwaggerGen.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <SignAssembly>false</SignAssembly>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <Authors>Dorin Mocan</Authors>
@@ -10,11 +10,11 @@
     <PackageTags>swagger openapi open api swashbuckle swaggergen documentation signalr hub websocket wss rest api web socket http doc generation extension handler handle intercept plugin auto standard net core microsoft web socket schema ui gen extension</PackageTags>
     <PackageProjectUrl>https://github.com/Dorin-Mocan/SignalRSwaggerGen</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Dorin-Mocan/SignalRSwaggerGen</RepositoryUrl>
-    <Version>3.2.1</Version>
-    <PackageReleaseNotes>Fixed default hub path template</PackageReleaseNotes>
-    <AssemblyVersion>3.2.1.0</AssemblyVersion>
+    <Version>5.0.0</Version>
+    <PackageReleaseNotes>Migrated to use Swashbuckle.AspNetCore.SwaggerGen v10.</PackageReleaseNotes>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <FileVersion>3.2.1.0</FileVersion>
+    <FileVersion>5.0.0.0</FileVersion>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <PackageIcon>Logo.png</PackageIcon>
     <PackageIconUrl />
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.3.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.*" />
   </ItemGroup>
 
 </Project>

--- a/SignalRSwaggerGen/TestWebApi/Startup.cs
+++ b/SignalRSwaggerGen/TestWebApi/Startup.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 
 namespace TestWebApi
 {
@@ -36,7 +36,11 @@ namespace TestWebApi
 			if (env.IsDevelopment())
 			{
 				app.UseDeveloperExceptionPage();
-				app.UseSwagger();
+				app.UseSwagger(options =>
+				{
+					options.OpenApiVersion = OpenApiSpecVersion.OpenApi3_1;
+				});
+
 				app.UseSwaggerUI(options =>
 				{
 					options.SwaggerEndpoint("/swagger/controllers/swagger.json", "REST API");

--- a/SignalRSwaggerGen/TestWebApi/TestWebApi.csproj
+++ b/SignalRSwaggerGen/TestWebApi/TestWebApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
When using this library with `Swashbuckle.AspNetCore.SwaggerGen` v10.x it crashes with `MethodNotFoundException` errors due to the method signature changes in the `OpenApi` dependency.

This update minimally migrates the code to use the latest SwaggerGen library version.

https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/HEAD/docs/migrating-to-v10.md#how-do-i-migrate-to-swashbuckleaspnetcore-v10